### PR TITLE
Changed the Website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # salesforce-yrs-festivalofcode
 A website of information for the Salesforce Centre - Young Rewired State - Festival of Code
 
-http://salesforce-yrs-festivalofcode.github.io/salesforce-yrs-festivalofcode
+http://festival-salesforce.github.io/
 


### PR DESCRIPTION
The Github Organisation was renamed, so the website it generates has a new web address (URL)